### PR TITLE
Support non-RGB images with --img_channels option

### DIFF
--- a/sourcecode/data_processing/DataLoader.py
+++ b/sourcecode/data_processing/DataLoader.py
@@ -140,43 +140,84 @@ class FoldersDistributedDataset(Dataset):
         return img
 
 
-def get_transform(new_size=None, flip_horizontal=False):
+class EnsureImageChannels:
+    """Transform that ensures the image has the expected number of channels.
+
+    :param img_channels: Expected number of channels. If the input image has the
+        expected channel count, it will be passed through without modification.
+        If it has a different number of channels, it will be either converted
+        to grayscale if ``img_channels=1`` or converted to RGB if
+        ``img_channels=3``. Else, an error will be raised.
+    :return: image, converted if necessary
+    """
+    def __init__(self, img_channels=3):
+        self.img_channels = img_channels
+        pil_modes = {3: "RGB", 1: "L"}
+        # If it's not one of these modes, the image won't be converted.
+        self.expected_mode = pil_modes.get(self.img_channels)
+
+    def __call__(self, img):
+        img_channels = len(img.getbands())
+        if img_channels != self.img_channels:
+            if self.img_channels == 1:
+                img = img.convert("L")  # Grayscale
+            elif self.img_channels == 3:
+                img = img.convert("RGB")
+            else:
+                raise RuntimeError(
+                    "Unable to load image with {} channels".format(img_channels))
+        return img
+
+
+def get_transform(new_size=None, flip_horizontal=False, img_channels=3):
     """
     obtain the image transforms required for the input data
     :param new_size: size of the resized images
     :param flip_horizontal: Whether to randomly mirror input images during training
+    :param img_channels: Expected number of channels. If the input image has the
+        expected channel count, it will be passed through without modification.
+        If it has a different number of channels, it will be either converted
+        to grayscale if ``img_channels=1`` or converted to RGB if
+        ``img_channels=3``. Else, an error will be raised.
     :return: image_transform => transform object from TorchVision
     """
     from torchvision.transforms import ToTensor, Normalize, Compose, Resize, \
         RandomHorizontalFlip
 
+    mean = tuple(0.5 for _ in range(img_channels))
+    std = tuple(0.5 for _ in range(img_channels))
+
     if not flip_horizontal:
         if new_size is not None:
             image_transform = Compose([
+                EnsureImageChannels(img_channels),
                 Resize(new_size),
                 ToTensor(),
-                Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5))
+                Normalize(mean=mean, std=std)
             ])
 
         else:
             image_transform = Compose([
+                EnsureImageChannels(img_channels),
                 ToTensor(),
-                Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5))
+                Normalize(mean=mean, std=std)
             ])
     else:
         if new_size is not None:
             image_transform = Compose([
+                EnsureImageChannels(img_channels),
                 RandomHorizontalFlip(p=0.5),
                 Resize(new_size),
                 ToTensor(),
-                Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5))
+                Normalize(mean=mean, std=std)
             ])
 
         else:
             image_transform = Compose([
+                EnsureImageChannels(img_channels),
                 RandomHorizontalFlip(p=0.5),
                 ToTensor(),
-                Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5))
+                Normalize(mean=mean, std=std)
             ])
 
     return image_transform

--- a/sourcecode/train.py
+++ b/sourcecode/train.py
@@ -151,6 +151,11 @@ def parse_arguments():
                         default=3,
                         help="number of parallel workers for reading files")
 
+    parser.add_argument("--img_channels", type=int,
+                        default=3,
+                        help="Channels in input images. E.g. this should be 3 "
+                             "for RGB images or 1 for grayscale images.")
+
     args = parser.parse_args()
     print('args={}'.format(args))
 
@@ -176,7 +181,8 @@ def main(args):
         args.images_dir,
         transform=get_transform((int(np.power(2, args.depth + 1)),
                                  int(np.power(2, args.depth + 1))),
-                                flip_horizontal=args.flip_augment))
+                                flip_horizontal=args.flip_augment,
+                                img_channels=args.img_channels))
 
     data = get_data_loader(dataset, args.batch_size, args.num_workers)
     print("Total number of images in the dataset:", len(dataset))
@@ -187,7 +193,8 @@ def main(args):
                       use_eql=args.use_eql,
                       use_ema=args.use_ema,
                       ema_decay=args.ema_decay,
-                      device=device)
+                      device=device,
+                      img_channels=args.img_channels)
 
     if args.generator_file is not None:
         # load the weights into generator


### PR DESCRIPTION
The expected number of image channels can now be expressed through the
`--img_channels` option. This option changes the generator and
discriminator architectures to generate/expect the given channel count
and changes the data loading mechanism to expect and - if necessary -
convert images to have this number of channels.

- Fixes the issue with occasional grayscale images in RGB photo data sets
  reported in #5 because if `--img_channels=3` (default), grayscale images
  are automatically converted to RGB in preprocessing.
- Adds support for training with grayscale images, as requested in #5.
- Should make it easier to implement training with multi-channel images that
  have more than 3 channels (which I'm planning to try soon).
- Enables training with RGB data sets in grayscale mode by simply setting
  `--img_channels=1`.

Disclaimer: I have not tested my changes with the usual data sets for image synthesis. I have only tried it with two small toy data sets: one of RGB images and one of grayscale images. My test trainings run without errors and the generated data visualization works, but my trainings don't converge yet and probably need some hyperparameter tuning (the discriminator loss is at 0 very often).